### PR TITLE
Fixed typo in regex

### DIFF
--- a/ui.schema.json
+++ b/ui.schema.json
@@ -580,7 +580,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^@[a-zA-Z0-9_]+\\.[a-zA-Z0.9_]+$"
+            "pattern": "^@[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+$"
           }
         },
         { "$ref": "#/definitions/vl:variable" }


### PR DESCRIPTION
I belive this is a small oversight as the general structure for references does allow numbers from 0-9 in references.